### PR TITLE
Add quotes to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       args:
         MAILCATCHER_VERSION: $VERSION
     ports:
-      - 1080:80
+      - "1080:80"
   test:
     image: tophfr/dockerize:latest
     depends_on:


### PR DESCRIPTION
It worked by luck without quotes, but with 1025:25 it doesn't, so quotes are necessary.