### PR TITLE
Install mailcatcher in version 0.7.1

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add --no-cache \
         libstdc++ \
         sqlite-libs
 
-ARG MAILCATCHER_VERSION=0.7.0
+ARG MAILCATCHER_VERSION=0.7.1
 
 RUN apk add --no-cache --virtual .build-deps \
         ruby-dev \


### PR DESCRIPTION
Hey @tophfr,
it looks like 0.7.1 version of Docker image contains mailcatcher 0.7.0.
Here are the changes to keep both versions consistent.

Best,
@szemek